### PR TITLE
BytesToString: add benchmarks against string(bytes)

### DIFF
--- a/zeroconv_test.go
+++ b/zeroconv_test.go
@@ -59,3 +59,39 @@ func TestLengthBytesPrefixedToString(t *testing.T) {
 		t.Fatalf("Mismatch:\nGot:  %q\nWant: %q\n", got, src)
 	}
 }
+
+var sink interface{}
+
+func BenchmarkBytesToString_Library(b *testing.B) {
+	cases := [][]byte{
+		[]byte("when it rains it pours"),
+		[]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, bs := range cases {
+			sink = BytesToString(bs)
+		}
+	}
+	if sink == nil {
+		b.Fatal("The benchmark was not run")
+	}
+}
+
+func BenchmarkBytesToString_Ordinary(b *testing.B) {
+	cases := [][]byte{
+		[]byte("when it rains it pours"),
+		[]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, bs := range cases {
+			sink = string(bs)
+		}
+	}
+	if sink == nil {
+		b.Fatal("The benchmark was not run")
+	}
+}


### PR DESCRIPTION
After running
```shell
$ go test -run=^$ -bench=. -count=10
```

and separating the content into:
* lib.txt for the benchmark output for BytesToString
* ordinary.txt for the usual string(bytes) conversion

the benchmark shows the improvement of switching to BytesToString:

```shell
$ benchstat ordinary.txt lib.txt
name             old time/op    new time/op    delta
BytesToString-8     104ns ± 5%      54ns ± 2%  -47.60%  (p=0.000 n=10+9)

name             old alloc/op   new alloc/op   delta
BytesToString-8      128B ± 0%       32B ± 0%  -75.00%  (p=0.000 n=10+10)

name             old allocs/op  new allocs/op  delta
BytesToString-8      4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.000 n=10+10)
```